### PR TITLE
Add in CODEOWNERS and pr template.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*.adoc          @eloots @ckipp01

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+_Insert any notes you may have here. If not, just delete this and keep the
+checklist down below_
+
+
+### Process
+
+Thanks for taking the time and writing a blog post! The process is quite
+simple to get this reviewed and merged. As you pass each step, feel free to
+tag whomever you may be waiting on to speed up the process. The process is as
+follows:
+
+- [ ] Content review
+- [ ] Grammar check
+
+Once these two steps are done all that is left is to hit the merge button!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lunatech-blog
-Contains our blog in Asciidoctor format.
+Contains our blog in [Asciidoctor](https://asciidoc.org/) format.
 
-Each post is localted in the `posts` directory with the following format: `yyyy-MM-dd-title.asciidoc`
+Each post is located in the `posts` directory with the following format: `yyyy-MM-dd-title.adoc`
 
 In the `media` directory there should be a matching image named `yyyy-MM-dd-title/background.png`
 
@@ -13,7 +13,7 @@ To add you blog post:
 * Checkout the forked repo
 * In the repo directory `g8 file://.`
 * Write your blog post
-* Submit a pull request
+* Submit a pull request and follow the template
 
 # Information regarding giter8
 
@@ -21,12 +21,13 @@ If you see this error :
 
   Error: giter8 has been disabled because it fetches unversioned dependencies at runtime!
   
-Then you can bypass the warning message as follow
+Then you can bypass the warning message by doing the following:
 
   brew edit giter8
   
-and delete this line  
+and delete this line:
+
   disable! because: "fetches unversioned dependencies at runtime"
-  
-then run brew install giter8 again
+
+then run brew install giter8 again.
 


### PR DESCRIPTION
So this is what I mentioned today as an alternative to a more involved multi-pr process or a process that involves swim lanes or something. I think the simpler we can keep it the better.

Basically when someone completes a blog and wants to send it in, they will automatically get the pr template that has a couple check items (the two that we talked about). Then can just check those off, or the person that is in charge of that stage can check them off. Also, if any thing is a adoc file or touching an adoc people can be automatically added as reviewers. I have an example here using CODEOWNERS. Let me know what you both think of this. Ideally we'd have a couple people to do content review and a couple people to do grammar review. So we should include 2 others in the CODEOWNERS. Let me know if you have someone in mind.