### PR TITLE
Update instructions on how to install giter8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ In the `media` directory there should be a matching image named `yyyy-MM-dd-titl
 All media used in the posts should be located in the `media` directory under a `yyyy-MM-dd-title` directory ie `media/yyy-MM-dd-title`
 
 To add you blog post:
-* Install giter8 `brew install giter8`
+* Install giter8, via coursier
+```commandline
+brew install coursier/formulas/coursier
+cs install giter8
+```
 * Fork this repo
 * Checkout the forked repo
 * In the repo directory `g8 file://.`


### PR DESCRIPTION
Brew formulae don't include giter8 anymore, it can be done with coursier now as explained in giter8 setup http://www.foundweekends.org/giter8/setup.html

To install coursier https://get-coursier.io/docs/cli-installation#macos-brew-based-installation