### PR TITLE
Fix job name for deployment to production

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  deploy_acceptance:
+  deploy_production:
     uses: ./.github/workflows/deploy_template.yaml
     with:
       clever_cloud_application: 'lunatech-blog-engine'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # lunatech-blog
-Contains our blog in [Asciidoctor](https://asciidoc.org/) format.
+## How It All Comes Together
+lunatech-blog contains our blog in [Asciidoctor](https://asciidoc.org/) format. We write blog posts in this repository. We then point a separate asciidoctor project (in our case currently [lunatech-blog-engine](https://github.com/lunatech-labs/lunatech-blog-engine)) to this project. That project then runs Asciidoctor on these files to convert and serve them as HTML.
 
 Each post is located in the `posts` directory with the following format: `yyyy-MM-dd-title.adoc`
 
@@ -7,7 +8,7 @@ In the `media` directory there should be a matching image named `yyyy-MM-dd-titl
 
 All media used in the posts should be located in the `media` directory under a `yyyy-MM-dd-title` directory ie `media/yyy-MM-dd-title`
 
-To add you blog post:
+To add your blog post:
 * Install giter8, via coursier
 ```commandline
 brew install coursier/formulas/coursier


### PR DESCRIPTION
The deployment to prod job was name 'deploy_acceptance'. This PR renames it and also adds a brief overview of the blog template and blog engine relationship